### PR TITLE
Add group-name parameter. Fix call to authorize-security-group-ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,14 @@ defined using the PORT variable.
 **Usage:**
 
 ```
-r53-healthchk-sg.sh -n <profile_name> -r <region> [ -p <port> ]
+r53-healthchk-sg.sh -n <profile_name> -r <region> -v <vpc-id> [ -g <group-name> ] [ -p <port> ]
 ```
 
 **Output:**
 
 ```
-./r53-healthchk-sg.sh -n eng -r us-east-1 -p 5300
+./r53-healthchk-sg.sh -n eng -r us-east-1 -v vpc-45338a20 -p 5300
 
-Enter your VPC-Id: vpc-45338a20
 Creating R53 health check security group ................ done!
 Security group Id: sg-60938505
 ```
@@ -122,3 +121,5 @@ aws ec2 describe-security-groups --group-ids sg-60938505 --profile eng
 
 - [x] Add a check for an existing security group
 - [x] Add multi-region support!
+- [x] Update existing security group instead of exiting
+- [x] Add ipv6 support


### PR DESCRIPTION
Sorry for the back-to-back PRs. My change in the previous PR wasn't consistently working in its invocation of authorize-security-group-ingress. I also added group-name as a parameter as I'm creating SecurityGroups in our environments in multiple VPCs per AWS account. Finally, I made a couple of relevant updates to the readme to reflect the changes from the last PR and this one.

Awscli authorize-security-group-ingress was not reading the parameters properly. Had to use backticks to resolve.